### PR TITLE
Update gtest paths to be arch agnostic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ find_package(Boost 1.74.0 COMPONENTS REQUIRED
 find_package(Protobuf REQUIRED)
 
 # Googletest (installed by sailbot_workspace Docker config)
-set(GTEST_LINK_LIBS "/usr/lib/x86_64-linux-gnu/libgtest.a" "/usr/lib/x86_64-linux-gnu/libgtest_main.a")
+execute_process(COMMAND arch OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(GTEST_LINK_LIBS "/usr/lib/${ARCH}-linux-gnu/libgtest.a" "/usr/lib/${ARCH}-linux-gnu/libgtest_main.a")
 
 # Add src directories
 add_subdirectory(lib)


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves https://github.com/UBCSailbot/sailbot_workspace/pull/79#issuecomment-1399193973
- The CMakeLists.txt uses the absolute path of the gtest install, but the path includes the CPU architecture. This PR changes it to get the architecture and hence set the path when building.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Verified the file path to the gtest install, as well as the output of the `arch` command on the Raspberry Pi running the Docker container.
