### PR TITLE
Add gh-token secret to caller workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,7 @@ jobs:
       # Rebuilds our docs site https://ubcsailbot.github.io/docs/
       # If the docs contains a snippet of a file in this repository, set to true
       rebuild-docs: false
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow
+    secrets:
+      # The repository secret `PAT_TOKEN` needs to exist, copy from Bitwarden
+      gh-token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
The new implementation of the `rebuild-docs` job requires a secret that must be passed from the caller workflow.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Tried out implementation in sailbot workspace

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- https://github.com/UBCSailbot/sailbot_workspace/pull/122
