### PR TITLE
Clear HTTP req_ before writing new request data to it from socket

### DIFF
--- a/projects/remote_transceiver/src/remote_transceiver.cpp
+++ b/projects/remote_transceiver/src/remote_transceiver.cpp
@@ -85,6 +85,7 @@ void Listener::run()
 void HTTPServer::readReq()
 {
     std::shared_ptr<HTTPServer> self = shared_from_this();
+    req_.clear();
     http::async_read(socket_, buf_, req_, [self](beast::error_code e, std::size_t /*bytesTransferred*/) {
         if (!e) {
             self->processReq();


### PR DESCRIPTION
### Description
in HTTPSERVER::readReq(), the req_ object is now cleared before writing to it

- Resolves #90 