### PR TITLE
Fix destructor order

### DIFF
--- a/projects/can_transceiver/src/can_transceiver.cpp
+++ b/projects/can_transceiver/src/can_transceiver.cpp
@@ -80,9 +80,9 @@ CanTransceiver::CanTransceiver(int fd) : sock_desc_(fd), is_can_simulated_(true)
 
 CanTransceiver::~CanTransceiver()
 {
-    close(sock_desc_);
     shutdown_flag_ = true;
     receive_thread_.join();
+    close(sock_desc_);
 }
 
 void CanTransceiver::receive()


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
Minor bug with the order in which resources are released in the CAN Transceiver destructor. Has no practical impact on performance, but outputs an error message in the unit tests.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [ ] 

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- 
