### PR TITLE
Update compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
-# Enable all warnings as errors except unused parameter because auto-generated protobuf files trigger it,
-# and clang-tidy can cover it without false-flagging the protobuf files.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter -pthread")
+# Enable all warnings as errors except nested-anon-types, as it allows us to declare an unnamed struct within an
+# anonymous union, which is allowed in the C++ standard. This appears to be a warning specific to clang++ with
+# -Wpedantic, and does not appear with g++ or MSVC
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -Wall -Wextra -Wpedantic -Werror -Wno-nested-anon-types -pthread")
 message(WARNING "Building Network Systems with build type '${CMAKE_BUILD_TYPE}' "
         "and flags: '${CMAKE_CXX_FLAGS}'")
 

--- a/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
+++ b/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
@@ -160,7 +160,7 @@ private:
      *
      * @param mock_gps mock_gps received from the Mock GPS topic
      */
-    void subMockGpsCb(msg::GPS mock_gps)
+    void subMockGpsCb(msg::GPS /*mock_gps*/)
     {
         // TODO(lross03): implement this
     }


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Re-enable unused parameter warning, as it is no longer causing problems with protobuf
- Disable nested-anon-types warning, which causes clang++ to flag standards compliant C++ code (g++ would not give a warning)
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [ ] 

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- 
